### PR TITLE
Fix save lag

### DIFF
--- a/app/assets/javascripts/ood_ace.js
+++ b/app/assets/javascripts/ood_ace.js
@@ -45,17 +45,15 @@ $( document ).ready(function () {
             if ( loading ) {
                 editor.session.getUndoManager().markClean();
             };
-            
+
             setSaveButtonState();
 
-            if (!editor.session.getUndoManager().isClean()) {
-                window.onbeforeunload = function (e) {
+            window.onbeforeunload = function (e) {
+                if (!editor.session.getUndoManager().isClean()) {
                     return 'You have unsaved changes!';
-                };
-            } else {
-                window.onbeforeunload = function (e) {
+                } else {
                     // return nothing
-                };
+                }
             };
         };
 


### PR DESCRIPTION
resolves https://github.com/AweSim-OSC/osc-fileeditor/issues/18

resolves https://github.com/AweSim-OSC/osc-fileeditor/issues/21

The changed state wasn't being marked until after the onChange event fired.

Incrementing the dirty counter manually on every change fixes this.
