### PR TITLE
Automatic syntax highlighting selection. Fixes #53.

### DIFF
--- a/app/assets/javascripts/ood_ace.js
+++ b/app/assets/javascripts/ood_ace.js
@@ -157,6 +157,16 @@ $( document ).ready(function () {
             };
         });
 
+        /**
+         * Returns the correct mode for ace editor according to the file extension of a filename.
+         *
+         * @param path {String} filename or extension (.js, .txt)
+         */
+        function getModeByFileExtension(path){
+            var modelist = ace.require("ace/ext/modelist");
+            return modelist.getModeForPath(path).mode;
+        }
+
         function setOptions() {
             $( "#keybindings" ).val(getCookie('keybindings') || "default");
             setKeyBinding();

--- a/app/assets/javascripts/ood_ace.js
+++ b/app/assets/javascripts/ood_ace.js
@@ -21,6 +21,7 @@ $( document ).ready(function () {
                 editor.destroy();
                 editor = ace.edit("editor");
                 initializeEditor();
+                setModeFromModelist();
                 $( "#loading-notice" ).toggle();
                 setBeforeUnloadState();
                 loading = false;
@@ -157,15 +158,12 @@ $( document ).ready(function () {
             };
         });
 
-        /**
-         * Returns the correct mode for ace editor according to the file extension of a filename.
-         *
-         * @param path {String} filename or extension (.js, .txt)
-         */
-        function getModeByFileExtension(path){
-            var modelist = ace.require("ace/ext/modelist");
-            return modelist.getModeForPath(path).mode;
-        }
+        // Automatically Sets the dropdown and mode to the modelist option
+        function setModeFromModelist() {
+            var modelist = ace.require("ace/ext/modelist").getModeForPath(filePath);
+            $( "#mode" ).val(modelist.name);
+            editor.session.setMode(modelist.mode);
+        };
 
         function setOptions() {
             $( "#keybindings" ).val(getCookie('keybindings') || "default");

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -37,7 +37,9 @@
 <% end %>
 
 <script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace-src-min-noconflict/ace.js" %>" type="text/javascript" charset="utf-8"></script>
+<script src="<%= "#{ENV['RAILS_RELATIVE_URL_ROOT']}/ace-src-min-noconflict/ext-modelist.js" %>" type="text/javascript" charset="utf-8"></script>
 <script>
   var editorContent = "";
   var apiUrl = "<%= @file_api_url %>";
+  var filePath = "<%= @pathname %>";
 </script>


### PR DESCRIPTION
Resolves #53.

Uses the ace `modelist` extension to automatically select the appropriate syntax highlighting on file load.

Modelist uses internal regexes to determine the appropriate mode for a file.

Examples: 

HTML: 
`/^.*\.(html|htm|xhtml)$/gi`
Ruby: 
`/rb$|^.*\.ru$|^.*\.gemspec$|^.*\.rake$|^Guardfile$|^Rakefile$|^Gemfile$/gi`
C & C++: 
`/^.*\.(cpp|c|cc|cxx|h|hh|hpp|ino)$/gi`

