### PR TITLE
Add optional whitelist for file editor

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,6 @@
 # This app does not use OOD_DATAROOT.
 # Remove once it is no longer in OodAppkit.
 OOD_DATAROOT=/dev/null
+
+# Paths not rooted in one of the below paths are forbidden (403'd)
+# WHITELIST_PATH="~/:/fs/project:/fs/scratch"

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@
 /vendor/bundle
 
 /.htaccess
-
+# SSHFS temp files
+._*

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,11 +1,16 @@
 class PagesController < ApplicationController
+  include PagesHelper
 
   def index
     path = params[:path] || "/"
     path = "/" + path unless path.start_with?("/")
 
     @pathname = Pathname.new(path)
-    if @pathname.file? && @pathname.readable?
+
+    if ! is_path_whitelisted?
+      @path_forbidden = true
+      render status: 403
+    elsif @pathname.file? && @pathname.readable?
       fileinfo = %x[ file -b --mime-type #{@pathname.to_s.shellescape} ]
       if fileinfo =~ /text\/|\/(x-empty|(.*\+)?xml)/ || params.has_key?(:force)
         @editor_content = ""
@@ -21,7 +26,6 @@ class PagesController < ApplicationController
       @not_found = true
       render status: 404
     end
-
   end
 
   def about

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,13 +1,11 @@
 class PagesController < ApplicationController
-  include PagesHelper
-
   def index
     path = params[:path] || "/"
     path = "/" + path unless path.start_with?("/")
 
     @pathname = Pathname.new(path)
 
-    if ! is_path_whitelisted?
+    if ! WhitelistPolicy.new(Rails.application.config.x.whitelist_paths).permitted?(@pathname)
       @path_forbidden = true
       render status: 403
     elsif @pathname.file? && @pathname.readable?

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,13 +1,18 @@
 module PagesHelper
-  # Determine if target is a child of root
-  # @param root [Pathname]
-  # @param target [Pathname]
+  # Determine if child is a subpath of parent
+  #
+  # If the relative path from the child to the supposed parent includes '..'
+  # then child is not a subpath of parent
+  #
+  # @param parent [Pathname]
+  # @param child [Pathname]
   # @return Boolean
-  def child?(root, target)
-    abs_root = root.expand_path.to_s.split('/')
-    abs_target = target.expand_path.to_s.split('/')
-    
-    (abs_root & abs_target) == abs_root
+  def child?(parent, child)
+    ! child.expand_path.relative_path_from(
+      parent.expand_path
+    ).each_filename.to_a.include?(
+      '..'
+    )
   end
 
   def whitelist

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,2 +1,20 @@
 module PagesHelper
+  # Determine if target is a child of root
+  # @param root [Pathname]
+  # @param target [Pathname]
+  # @return Boolean
+  def child?(root, target)
+    abs_root = root.expand_path.to_s.split('/')
+    abs_target = target.expand_path.to_s.split('/')
+    
+    (abs_root & abs_target) == abs_root
+  end
+
+  def whitelist
+    ::Rails.application.config.whitelist_paths
+  end
+
+  def is_path_whitelisted?
+    whitelist.empty? || whitelist.any?{|parent| child?(parent, @pathname)}
+  end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,25 +1,2 @@
 module PagesHelper
-  # Determine if child is a subpath of parent
-  #
-  # If the relative path from the child to the supposed parent includes '..'
-  # then child is not a subpath of parent
-  #
-  # @param parent [Pathname]
-  # @param child [Pathname]
-  # @return Boolean
-  def child?(parent, child)
-    ! child.expand_path.relative_path_from(
-      parent.expand_path
-    ).each_filename.to_a.include?(
-      '..'
-    )
-  end
-
-  def whitelist
-    ::Rails.application.config.whitelist_paths
-  end
-
-  def is_path_whitelisted?
-    whitelist.empty? || whitelist.any?{|parent| child?(parent, @pathname)}
-  end
 end

--- a/app/models/whitelist_policy.rb
+++ b/app/models/whitelist_policy.rb
@@ -1,0 +1,42 @@
+require 'pathname'
+
+class WhitelistPolicy
+  attr_reader :whitelist
+
+  def initialize(whitelist)
+    @whitelist = whitelist
+  end
+
+  # @raises ArgumentError if any whitelist path or permitted? argument
+  #         has the form ~user/some/path where user doesn't exist
+  def permitted?(path)
+    whitelist.blank? || whitelist.any?{ |parent| child?(Pathname.new(parent), real_expanded_path(path)) }
+  end
+
+  protected
+
+  # call realpath to ensure symlinks are handled
+  def real_expanded_path(path)
+     # call realpath to ensure symlinks are resolved
+     Pathname.new(path).expand_path.realpath
+   rescue SystemCallError
+     # path doesn't exist, so we just get absolute version then
+     Pathname.new(path).expand_path
+   end
+
+  # Determine if child is a subpath of parent
+  #
+  # If the relative path from the child to the supposed parent includes '..'
+  # then child is not a subpath of parent
+  #
+  # @param parent [Pathname]
+  # @param child [Pathname]
+  # @return Boolean
+  def child?(parent, child)
+    ! child.expand_path.relative_path_from(
+      parent.expand_path
+    ).each_filename.to_a.include?(
+      '..'
+    )
+  end
+end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,4 +1,3 @@
-
 <% if @editor_content %>
     <div id="error">
       <h2>
@@ -33,6 +32,10 @@
 <% elsif @not_found %>
     <h2><span class="label label-danger">File Not Found!</span></h2>
     <h3>The file or folder could not be found.</h3>
+    
+<% elsif @path_forbidden %>
+    <h2><span class="label label-danger">Path Forbidden!</span></h2>
+    <h3>The file or folder cannot be loaded.</h3>
     <h4><pre><%= @pathname %></pre></h4>
 <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,8 @@ module OODApp
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    # Whitelist paths are stored in a colon delimited list in the environment variable WHITELIST_PATH
+    config.whitelist_paths = (path = ENV['WHITELIST_PATH']) ? path.split(':').map{|s| Pathname.new(s)} : []
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,6 @@ module OODApp
     # config.i18n.default_locale = :de
 
     # Whitelist paths are stored in a colon delimited list in the environment variable WHITELIST_PATH
-    config.whitelist_paths = (path = ENV['WHITELIST_PATH']) ? path.split(':').map{|s| Pathname.new(s)} : []
+    config.x.whitelist_paths = (path = ENV['WHITELIST_PATH']) ? path.split(':').map{|s| Pathname.new(s)} : []
   end
 end


### PR DESCRIPTION
Utilize the environment variable `WHITELIST_PATH` to define an optional set of paths that are the only paths that can be viewed/edited. An empty whitelist permits viewing/editing of any path that the user would normally have permissions for. If the whitelist is defined then, any requested path that is not in rooted in a member of the whitelist returns an error message and a 403. This check occurs before checking if the requested path actually exists so as not to leak information about the filesystem.