### PR TITLE
bin/setup patch for debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- bin/setup patched for debian
+
 ## [1.4.4] - 2019-08-22
 ### Fixed
 - Upgraded jQuery and Nokogiri

--- a/bin/setup
+++ b/bin/setup
@@ -46,7 +46,7 @@ chdir APP_ROOT do
   puts "RAILS_ENV               = #{APP.env}"
   puts "RAILS_RELATIVE_URL_ROOT = #{APP.url || "not set"}"
 
-  unless system("bin/bundle check 2>&1 >/dev/null")
+  unless system("bin/bundle check >/dev/null 2>&1")
     puts "\n== Installing dependencies =="
     sh "bin/bundle install --path=vendor/bundle"
     sh "bin/bundle clean"

--- a/bin/setup
+++ b/bin/setup
@@ -46,7 +46,7 @@ chdir APP_ROOT do
   puts "RAILS_ENV               = #{APP.env}"
   puts "RAILS_RELATIVE_URL_ROOT = #{APP.url || "not set"}"
 
-  unless system("bin/bundle check &> /dev/null")
+  unless system("bin/bundle check 2>&1 >/dev/null")
     puts "\n== Installing dependencies =="
     sh "bin/bundle install --path=vendor/bundle"
     sh "bin/bundle clean"


### PR DESCRIPTION
For clarity, the first thing is what should happen, just returns 'false'.  The other 2 are what should not happen, i.e., stderr is being shown in the second example and in the third (what's really bad, and is the original line) true is returned.

```ruby
irb(main):001:0> system("bin/bundle check >/dev/null 2>&1")
=> false
irb(main):002:0> system("bin/bundle check 2>&1 >/dev/null")
Traceback (most recent call last):
	2: from bin/bundle:3:in `<main>'
	1: from /usr/lib/ruby/2.5.0/rubygems.rb:263:in `bin_path'
/usr/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': Could not find 'bundler' (1.13.7) required by your /tmp/ood-fileeditor/Gemfile.lock. (Gem::GemNotFoundException)
To update to the lastest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.13.7`
=> false
irb(main):003:0> system("bin/bundle check &>/dev/null")
=> true
irb(main):004:0> Traceback (most recent call last):
	2: from bin/bundle:3:in `<main>'
	1: from /usr/lib/ruby/2.5.0/rubygems.rb:263:in `bin_path'
/usr/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': Could not find 'bundler' (1.13.7) required by your /tmp/ood-fileeditor/Gemfile.lock. (Gem::GemNotFoundException)
To update to the lastest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.13.7`

irb(main):005:0> system("bin/bundle check &> /dev/null")
=> true
irb(main):006:0> Traceback (most recent call last):
	2: from bin/bundle:3:in `<main>'
	1: from /usr/lib/ruby/2.5.0/rubygems.rb:263:in `bin_path'
/usr/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': Could not find 'bundler' (1.13.7) required by your /tmp/ood-fileeditor/Gemfile.lock. (Gem::GemNotFoundException)
To update to the lastest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.13.7`
```

